### PR TITLE
streamlined windows macros, hopefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,18 @@
+# build crap?
 *.o
 *.~*
 *.#*
+
+# cmake files
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake
 install_manifest.txt
 Makefile
+
+# VS directories
 out/**
 .vs/**
+
+# for codemaid
+Debug/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ ENDIF()
 #
 if(WIN32)
   # Add Windows flags/options
-  ADD_DEFINITIONS(-DWINDOWS)
+  #ADD_DEFINITIONS(-DWINDOWS)
   SET(EXECUTABLE_OPTIONS WIN32)
   SET(LIBS ${LIBS} winmm wsock32)
 endif(WIN32)

--- a/src/angband.h
+++ b/src/angband.h
@@ -47,7 +47,7 @@ extern "C" {
 /*
  * SGLIB
  */
-#include "sglib.h"
+#include "include/sglib.h"
 
 
 /*

--- a/src/config.h
+++ b/src/config.h
@@ -153,7 +153,7 @@
 /*
  * OPTION: Hack -- Windows stuff
  */
-#ifdef WINDOWS
+#ifdef WIN32
 
 /* Do not handle signals */
 # undef HANDLE_SIGNALS

--- a/src/externs.h
+++ b/src/externs.h
@@ -2277,12 +2277,7 @@ extern u32b _fcreator;
 extern u32b _ftype;
 #endif /* MACH_O_CARBON */
 
-#ifdef WINDOWS
-/* main-win.c */
-/* extern int FAR PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, ...); */
-#endif
-
-#if !defined(WINDOWS) && !defined(MACINTOSH)
+#if !defined(WIN32) && !defined(MACINTOSH)
 /* files.c */
 extern bool_ chg_to_txt(cptr base, cptr newname);
 #endif /* !WINDOWS && !MACINTOSH */

--- a/src/files.c
+++ b/src/files.c
@@ -4053,7 +4053,7 @@ void process_player_name(bool_ sf)
 #endif
 
 
-#if defined(WINDOWS) || defined(MSDOS)
+#if defined(WIN32)
 
 	/* Hack -- max length */
 	if (k > 8) k = 8;

--- a/src/h-config.h
+++ b/src/h-config.h
@@ -28,8 +28,8 @@
 /*
  * OPTION: Compile on Windows (automatic)
  */
-#ifndef WINDOWS
-/* #define WINDOWS */
+#ifndef WIN32
+/* #define WIN32 */
 #endif
 
 /*
@@ -121,26 +121,11 @@
 #endif
 
 /*
- * Extract the "MSDOS" flag from the compiler
- */
-#ifdef __MSDOS__
-# ifndef MSDOS
-#  define MSDOS
-# endif
-#endif
-
-/*
  * Extract the "WINDOWS" flag from the compiler
  */
-#if defined(_Windows) || defined(__WINDOWS__) || \
-    defined(__WIN32__) || defined(WIN32) || \
-    defined(__WINNT__) || defined(__NT__)
-# ifndef WINDOWS
-#  define WINDOWS
-# endif
+#if defined(_WIN32)
+# define WIN32
 #endif
-
-
 
 /*
  * OPTION: Define "L64" if a "long" is 64-bits.  See "h-types.h".
@@ -150,8 +135,6 @@
 #if defined(__alpha) && defined(__osf__) || defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(__ia64) || defined(__ia64__) || defined(__mips64) || defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__) || defined(__64BIT__) || defined(__sparc64__) || defined(__LP64__)
 # define L64
 #endif
-
-
 
 /*
  * OPTION: set "SET_UID" if the machine is a "multi-user" machine.
@@ -164,8 +147,7 @@
  * Basically, SET_UID should *only* be set for "Unix" machines,
  * or for the "Atari" platform which is Unix-like, apparently
  */
-#if !defined(MACINTOSH) && !defined(WINDOWS) && \
-    !defined(MSDOS)
+#if !defined(MACINTOSH) && !defined(WIN32)
 # define SET_UID
 #endif
 
@@ -200,11 +182,7 @@
 # undef PATH_SEP
 # define PATH_SEP ":"
 #endif
-#if defined(WINDOWS) || defined(WINNT)
-# undef PATH_SEP
-# define PATH_SEP "/"
-#endif
-#if defined(MSDOS) || defined(OS2)
+#if defined(OS2)
 # undef PATH_SEP
 # define PATH_SEP "\\"
 #endif
@@ -230,7 +208,7 @@
 /*
  * OPTION: Hack -- Make sure "strchr()" and "strrchr()" will work
  */
-#if defined(SYS_III) || defined(SYS_V) || defined(MSDOS)
+#if defined(SYS_III) || defined(SYS_V)
 # if !defined(__TURBOC__) && !defined(__WATCOMC__)
 #  define strchr index
 #  define strrchr rindex
@@ -242,7 +220,9 @@
  * OPTION: Define "HAS_STRICMP" only if "stricmp()" exists.
  * Note that "stricmp()" is not actually used by Angband.
  */
-/* #define HAS_STRICMP */
+#if defined(WIN32)
+# define HAS_STRICMP
+#endif
 
 /*
  * Linux has "stricmp()" with a different name

--- a/src/h-system.h
+++ b/src/h-system.h
@@ -47,7 +47,7 @@
 # include <unix.h>
 #endif
 
-#if defined(WINDOWS) || defined(MSDOS)
+#if defined(WIN32)
 # include <io.h>
 #endif
 
@@ -118,7 +118,7 @@ extern char *strrchr();
 
 
 
-#if !defined(linux) && !defined(__MWERKS__)
+#if !defined(linux) && !defined(__MWERKS__) && !defined(WIN32)
 extern long atol();
 #endif
 

--- a/src/h-type.h
+++ b/src/h-type.h
@@ -72,7 +72,7 @@ typedef int errr;
 #define uint uint_hack
 
 /*
- * Hack -- prevent problems with MSDOS and WINDOWS
+ * Hack -- prevent problems with WINDOWS
  */
 #undef huge
 #define huge huge_hack

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@
  */
 
 
-#if !defined(MACINTOSH) && !defined(WINDOWS)
+#if !defined(MACINTOSH) && !defined(WIN32)
 
 
 /*

--- a/src/modules.c
+++ b/src/modules.c
@@ -22,7 +22,7 @@ static void module_reset_dir_aux(cptr *dir, cptr new_path)
 	string_free(*dir);
 	*dir = string_make(buf);
 
-#if !defined(MACINTOSH) && !defined(WINDOWS)
+#if !defined(MACINTOSH) && !defined(WIN32)
 	/* Make it if needed */
 	if (!private_check_user_directory(*dir))
 		quit(format("Unable to create module dir %s\n", *dir));
@@ -61,7 +61,7 @@ void module_reset_dir(cptr dir, cptr new_path)
 		string_free(*d);
 		*d = string_make(buf);
 
-#if !defined(MACINTOSH) && !defined(WINDOWS)
+#if !defined(MACINTOSH) && !defined(WIN32)
 		// Make it if needed */
 		if (!private_check_user_directory(*d))
 		{

--- a/src/readdib.c
+++ b/src/readdib.c
@@ -17,30 +17,16 @@
  *   Sample Application Files which are modified.
  */
 
-#ifdef WINDOWS
+#ifdef WIN32
 
 #include <windows.h>
-
 #include "readdib.h"
-
-
-/*
- * Extract the "WIN32" flag from the compiler
- */
-#if defined(__WIN32__) || defined(__WINNT__) || defined(__NT__)
-# ifndef WIN32
-# define WIN32
-# endif 
-#endif
 
 /*
  * Make sure "huge" is legal XXX XXX XXX
  */
 #undef huge
-#ifdef WIN32
-# define huge /* oops */
-#endif
-
+#define huge /* oops */
 
 /*
  * Number of bytes to be read during each read operation
@@ -49,9 +35,7 @@
 
 /*
  * Private routine to read more than 64K at a time
- *
  * Reads data in steps of 32k till all the data has been read.
- *
  * Returns number of bytes requested, or zero if something went wrong.
  */
 static DWORD PASCAL lread(int fh, VOID far *pv, DWORD ul)
@@ -74,7 +58,6 @@ static DWORD PASCAL lread(int fh, VOID far *pv, DWORD ul)
 
 /*
  * Given a BITMAPINFOHEADER, create a palette based on the color table.
- *
  * Returns the handle of a palette, or zero if something went wrong.
  */
 static HPALETTE PASCAL NEAR MakeDIBPalette(LPBITMAPINFOHEADER lpInfo)

--- a/src/util.c
+++ b/src/util.c
@@ -255,7 +255,7 @@ errr path_parse(char *buf, int max, cptr file)
 */
 errr path_temp(char *buf, int max)
 {
-#ifdef WINDOWS
+#ifdef WIN32
 	static u32b tmp_counter;
 	static char valid_characters[] =
 			"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";


### PR DESCRIPTION
"modernizing" macros as I understand things. 

- Removed passing WINDOWS definition in cmake.
- Removed WINDOWS definition, as well as checks for ancient versions of the os.
- Added check for _WIN32 which defines WIN32 in code,
- Removed checks for WIN32 within code already checked for it.